### PR TITLE
Remove XSRF workaround & open WebCAT in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ Follow these steps if you are running Jupyter Notebooks through Anaconda:
 3. jupyter serverextension enable --py webcatjupyterplugin
 4. jupyter nbextension install --py webcatjupyterplugin
 5. jupyter nbextension enable --py webcatjupyterplugin
-7. Download the file env.sh or clone the repository and run the command below
-8. sh env.sh
-
-You can skip the 7<sup>th</sup> and 8<sup>th</sup> steps and manually run the following commands:
-1. jupyter notebook --generate-config
-2. Add the following line at the end of ~/.jupyter/jupyter_notebook_config.py
-    - c.NotebookApp.disable_check_xsrf = True 
     
 ##### With pip:
 
@@ -35,15 +28,7 @@ If you are not using Anaconda, use the following commands:
 2. jupyter serverextension enable --py webcatjupyterplugin
 3. jupyter nbextension install --py webcatjupyterplugin
 4. jupyter nbextension enable --py webcatjupyterplugin
-5. Download the file env.sh or clone the repository and run the command below
-6. sh env.sh
 
-
-You can skip the 5<sup>th</sup> and 6<sup>th</sup> steps and manually run the following commands:
-1. jupyter notebook --generate-config
-2. Add the following line at the end of ~/.jupyter/jupyter_notebook_config.py
-    - c.NotebookApp.disable_check_xsrf = True 
-    
 ## Windows
 
 If you have Windows operating system, follow these steps:
@@ -55,15 +40,6 @@ If you have Windows operating system, follow these steps:
 5. jupyter serverextension enable --py webcatjupyterplugin
 6. jupyter nbextension install --py webcatjupyterplugin
 7. jupyter nbextension enable --py webcatjupyterplugin
-8. jupyter notebook --generate-config
-
-This will generate a default config file and you will get the output like "Writing default config to: C:\Users\UserName\\.jupyter\jupyter_notebook_config.py"
-
-Run the following command but make sure to change the path to the ones returned by the above command
-
-9. echo c.NotebookApp.disable_check_xsrf = True >> C:\Users\UserName\\.jupyter\jupyter_notebook_config.py
-
-
 
 # Assignment Indentification
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,0 @@
-####################### Changes in jupyter config ###########################
-if [ ! -f ~/.jupyter/jupyter_notebook_config.py ]; then
-   jupyter notebook --generate-config
-fi
-
-echo 'c.NotebookApp.disable_check_xsrf = True' >> ~/.jupyter/jupyter_notebook_config.py

--- a/webcatjupyterplugin/static/main.js
+++ b/webcatjupyterplugin/static/main.js
@@ -55,6 +55,7 @@ define([
                 url: '/webcat/push',
                 processData: false,
                 type: "PUT",
+                headers: {},
                 dataType: "json",
                 data: JSON.stringify(payload),
                 contentType: 'application/json',
@@ -74,6 +75,12 @@ define([
                     alert("Error while submitting to Web-CAT");
                 }
             };
+
+            // https://blog.jupyter.org/security-release-jupyter-notebook-4-3-1-808e1f3bb5e2
+            var xsrf_token = document.cookie.match("\\b_xsrf=([^;]*)\\b")?.[1]
+            if (xsrf_token) {
+                settings.headers['X-XSRFToken'] = xsrf_token
+            }
 
             // commit and push
             $.ajax(settings);

--- a/webcatjupyterplugin/static/main.js
+++ b/webcatjupyterplugin/static/main.js
@@ -7,14 +7,6 @@ define([
         var submitActionName = 'submit-to-webcat';
 
         function load_ipython_extension() {
-            $('<link/>')
-                .attr({
-                    id: 'collapsible_headings_css',
-                    rel: 'stylesheet',
-                    type: 'text/css',
-                    href: requirejs.toUrl('./main.css')
-                })
-                .appendTo('head');
 
             var action = {
                 span: 'Submit to Web-CAT',

--- a/webcatjupyterplugin/static/main.js
+++ b/webcatjupyterplugin/static/main.js
@@ -60,16 +60,7 @@ define([
                 data: JSON.stringify(payload),
                 contentType: 'application/json',
                 success: function (data) {
-                    var iframe_html = '<iframe src="' + data.redirectLink +
-                        '" width = 650 height = 500></iframe>';
-                    dialog.modal({
-                        title: "Web-CAT",
-                        body: iframe_html,
-                        sanitize: false,
-                        buttons: {
-                            'Close': {}
-                        }
-                    });
+                    window.open(data.redirectLink);
                 },
                 error: function (data) {
                     alert("Error while submitting to Web-CAT");


### PR DESCRIPTION
This [article](https://blog.jupyter.org/security-release-jupyter-notebook-4-3-1-808e1f3bb5e2) describes how to properly send the XSRF token stored in the cookie with requests to Jupyter's REST API.

This removes the need to disable XSRF protection on the entire notebook server, so I've removed the script and associated documentation.

Additionally, there were authentication issues using WebCAT in an iframe, so instead this simply opens the link in a new tab.

There's also a commit to delete the extraneous HTML element that tries to load a non-existent CSS file.